### PR TITLE
Stop accumulating rockets

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -61,14 +61,14 @@ export const getPads = (locationId, name) => {
 export const getLaunchData = (padId) => {
   return dispatch => {
     // 'locationid' param in launch API is wrong - should be the pad ID
-    fetch(URL_ROOT + 'launch/?limit=200&locationid=' + padId)
+    fetch(URL_ROOT + 'launch/?limit=30&locationid=' + padId)
       .then(response => response.json())
       .then(responseBody => {
         if (responseBody.status === 'error') {
           dispatch(gotLaunchDataError(padId, responseBody));
         } else {
-          if (responseBody.total > 200) {
-            console.log('over 200 launches');
+          if (responseBody.total > 30) {
+            console.log('over 30 launches @ pad:', padId);
           }
           dispatch(gotLaunchData(padId, responseBody));
         }

--- a/src/components/rocketlist.js
+++ b/src/components/rocketlist.js
@@ -9,7 +9,7 @@ const RocketList = props => {
           {props.rockets.length > 0 && props.rockets.map((rocket, index) => {
             return (
               <div className="rocket-item" key={index}>
-                <div>{rocket.name}</div>
+                <div><strong>{rocket.name}</strong></div>
                 <div>Family: {rocket.familyname}</div>
                 <div>Configuration: {rocket.configuration}</div>
               </div>

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -47,22 +47,25 @@ const launchDataReducer = (state = {}, action) => {
     case GOT_LAUNCH_DATA:
     case GOT_LAUNCH_DATA_ERROR:
       // Object.assign and spread operator only do a shallow copy
-      const rockets = _.isEmpty(state.rockets) ? {} : _.clone(state.rockets);
+      const rockets = _.clone(state.rockets || {});
+      const currentRockets = {};
 
       action.data.launches.forEach((launch) => {
-        if (!rockets[launch.rocket.id]) {
-          rockets[launch.rocket.id] = {
-            id: launch.rocket.id,
-            name: launch.rocket.name,
-            configuration: launch.rocket.configuration,
-            familyname: launch.rocket.familyname,
-          };
+        const rocket = {
+          id: launch.rocket.id,
+          name: launch.rocket.name,
+          configuration: launch.rocket.configuration,
+          familyname: launch.rocket.familyname
+        };
+        currentRockets[rocket.id] = { ...rocket };
+        if (!rockets[rocket.id]) {
+          rockets[rocket.id] = { ...rocket };
         }
       });
 
       return {
         ...state,
-        pads: padsReducer(state.pads, action, rockets),
+        pads: padsReducer(state.pads, action, currentRockets),
         rockets
       };
     default:


### PR DESCRIPTION
List of current rockets (for the pad that was clicked) was accumulating. So each subsequent click of a pad would show the rockets from that pad, plus all the rockets loaded for other pads until then.